### PR TITLE
Fixed Firefox 71 detection

### DIFF
--- a/src/desktop/firefox.js
+++ b/src/desktop/firefox.js
@@ -21,7 +21,7 @@ export function detectFirefox() {
       browserVersion = 73;
     } else if ($.hasFeature('FormDataEvent')) {
       browserVersion = 72;
-    } else if ($.hasFeature('MediaMetadata')) {
+    } else if ($.hasFeature('MathMLElement')) {
       browserVersion = 71;
     } else if ($.hasFeature('AudioContext.prototype.baseLatency')) {
       browserVersion = 70;


### PR DESCRIPTION
Changed the feature detection from `MediaMetadata` to `MathMLElement`.