### PR TITLE
Handled undefined `window`

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -48,6 +48,6 @@ var helpers = {
     return false;
   },
 
-  windowObject: window
+  windowObject: typeof window !== 'undefined' ? window : null
 };
 export default helpers;


### PR DESCRIPTION
#### What I'm doing
Handled undefined `window`. This is useful if you run the library from NodeJS instead of a browser.